### PR TITLE
Update _html-elements.scss

### DIFF
--- a/src/scss/30-global/_html-elements.scss
+++ b/src/scss/30-global/_html-elements.scss
@@ -22,6 +22,13 @@ img {
   height: auto;
 }
 
+// All last children
 :last-child {
   margin-bottom: 0;
 }
+
+// all last children with a class
+[class]:last-child { 
+  margin-bottom: 0;
+} 
+ 


### PR DESCRIPTION
:last-child{} specificity of 10 will override any single element selector (div, p, li, ul) which is specificity of 1

But `.foo p { }` will be specificity of 11, which allows you to still apply margin if needed.

But since `.foo` is also 10, it will override :last-child if placed after that declaration.

`[class]:last-child` has a specificity of 20, and allows you to scope it to just items with classes.

---

Does this zero out bottom margin of:

`p` : YES 
`.foo p`: NO
`.foo`: YES
`.foo .bar p`: NO