### PR TITLE
Remove quotes.

### DIFF
--- a/source/_patterns/01-atoms/01-typography/text/_text.scss
+++ b/source/_patterns/01-atoms/01-typography/text/_text.scss
@@ -12,7 +12,7 @@
 /// @param $hover
 /// @param $deco
 /// @param $deco--hover
-@mixin a-link($link: $c-red, $hover: $c-red, $deco: "none", $deco--hover: "underline") {
+@mixin a-link($link: $c-red, $hover: $c-red, $deco: none, $deco--hover: underline) {
   &:link,
   &:visited {
     color: $link;


### PR DESCRIPTION
With quotes, Firefox inspector gave an error warning, and the underline was present for the default link. With the quotes removed, the link worked as expected (no underline by default, underline present on hover.)