### PR TITLE
[HOLD] Introduce the default 'startup:start' and 'startup:stop' tasks

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,6 +24,8 @@ gulp.task('validate', gulp.parallel(tasks.validate));
 gulp.task('watch', gulp.parallel(tasks.watch));
 tasks.default.push('watch');
 gulp.task('default', gulp.series(
+  'startup:start',
   'compile',
-  gulp.parallel(tasks.default)
+  gulp.parallel(tasks.default),
+  'startup:stop'
 ));


### PR DESCRIPTION
These tasks are introduced in this PR to p2-theme-core: https://github.com/phase2/p2-theme-core/pull/15

Essentially, we now have a "startup mode" that certain tasks can check against to allow them to not run redundantly on first `npm run start`. This modifies the `default` task in pattern-lab-starter to add in these two tasks.