### PR TITLE
[HOLD] Adding Webpack

### DIFF
--- a/gulpconfig.js
+++ b/gulpconfig.js
@@ -68,6 +68,10 @@ module.exports = {
       ],
     },
   },
+  webpack: {
+    enabled: true,
+    config: require('./webpack.config.js'),
+  },
   patternLab: {
     enabled: true,
     configFile: 'pattern-lab/config/config.yml',
@@ -83,10 +87,10 @@ module.exports = {
     ],
     injectFiles: [
       'source/styleguide/custom-styleguide-specific.css',
-      'bower_components/underscore/underscore.js',
-      'bower_components/jquery-once/jquery.once.js',
-      'bower_components/holderjs/holder.js',
-      'bower_components/drupal/index.js',
+      // 'bower_components/underscore/underscore.js',
+      // 'bower_components/jquery-once/jquery.once.js',
+      // 'bower_components/holderjs/holder.js',
+      // 'bower_components/drupal/index.js',
     ],
     bowerBasePath: './',
     twigNamespaces: {

--- a/gulpconfig.js
+++ b/gulpconfig.js
@@ -45,7 +45,7 @@ module.exports = {
     },
   },
   js: {
-    enabled: true,
+    enabled: false,
     src: [
       'js/**/*.js',
       'source/_patterns/**/*.js',

--- a/js/main-entry.js
+++ b/js/main-entry.js
@@ -1,0 +1,3 @@
+import util from './util.js';
+
+document.body.classList.add(util.getTestText());

--- a/js/script.js
+++ b/js/script.js
@@ -1,7 +1,0 @@
-(function mainThemeScript($, Drupal) {
-  Drupal.behaviors.plStarter = {
-    attach(context) {
-      $('html', context).addClass('js');
-    },
-  };
-}(jQuery, Drupal));

--- a/js/script2.js
+++ b/js/script2.js
@@ -1,7 +1,0 @@
-(function secondaryThemeScript($, Drupal) {
-  Drupal.behaviors.demo2 = {
-    attach(context) {
-      $('html', context).addClass('js2');
-    },
-  };
-}(jQuery, Drupal));

--- a/js/util.js
+++ b/js/util.js
@@ -1,0 +1,7 @@
+function getTestText() {
+  return 'test-text';
+}
+
+export default {
+  getTestText,
+};

--- a/package.json
+++ b/package.json
@@ -26,10 +26,11 @@
     "bower": "bower"
   },
   "dependencies": {
+    "babel-loader": "^6.4.1",
     "babel-preset-es2015": "^6.24.0",
     "bower": "^1.8.0",
     "gulp": "gulpjs/gulp#4.0",
-    "p2-theme-core": "^9.3.1",
+    "p2-theme-core": "^9.4.3",
     "rc": "^1.2.0",
     "stylelint-scss": "^1.4.3"
   },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "scripts": {
     "start": "gulp",
-    "compile": "gulp compile",
+    "compile": "NODE_ENV=production gulp compile",
     "test": "gulp validate",
     "gulp": "gulp",
     "update": "npm update && cd pattern-lab && composer update",

--- a/source/_meta/_01-foot.twig
+++ b/source/_meta/_01-foot.twig
@@ -9,7 +9,6 @@
   <script src="../../../../bower_components/holderjs/holder.js?cacheBuster={{ cacheBuster }}"></script>
   <script src="../../../../bower_components/jquery-once/jquery.once.js?cacheBuster={{ cacheBuster }}"></script>
   <script src="../../../../bower_components/underscore/underscore.js?cacheBuster={{ cacheBuster }}"></script>
-  <script src="../../../../dest/script.js?cacheBuster={{ cacheBuster }}"></script>
   <!-- endinject -->
 
 	</body>

--- a/source/_meta/_01-foot.twig
+++ b/source/_meta/_01-foot.twig
@@ -2,13 +2,8 @@
 	<!--DO NOT REMOVE-->
 	{{ patternLabFoot | raw }}
 
-  <script src="../../../bower_components/domready/ready.js?cacheBuster={{ cacheBuster }}"></script>
-  <script src="../../../bower_components/jquery/dist/jquery.js?cacheBuster={{ cacheBuster }}"></script>
   <!-- inject:js -->
-  <script src="../../../../bower_components/drupal/index.js?cacheBuster={{ cacheBuster }}"></script>
-  <script src="../../../../bower_components/holderjs/holder.js?cacheBuster={{ cacheBuster }}"></script>
-  <script src="../../../../bower_components/jquery-once/jquery.once.js?cacheBuster={{ cacheBuster }}"></script>
-  <script src="../../../../bower_components/underscore/underscore.js?cacheBuster={{ cacheBuster }}"></script>
+  <script src="../../../../dest/theme-main-entry.js?cacheBuster={{ cacheBuster }}"></script>
   <!-- endinject -->
 
 	</body>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,20 @@
+const path = require('path');
+
+module.exports = {
+  entry: {
+    'theme-main-entry': './js/main-entry',
+  },
+  output: {
+    filename: '[name].js',
+    path: path.resolve(__dirname, 'dest'),
+  },
+  module: {
+    loaders: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        use: ['babel-loader'],
+      },
+    ],
+  },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -311,15 +311,7 @@ aws4@^1.2.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.5.0.tgz#0a29ffb79c31c9e712eeb087e8e7a64b4a56d755"
 
-babel-code-frame@^6.16.0:
-  version "6.16.0"
-  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.16.0.tgz#f90e60da0862909d3ce098733b5d3987c97cb8de"
-  dependencies:
-    chalk "^1.1.0"
-    esutils "^2.0.2"
-    js-tokens "^2.0.0"
-
-babel-code-frame@^6.22.0:
+babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
   dependencies:
@@ -440,17 +432,20 @@ babel-helpers@^6.16.0:
     babel-runtime "^6.0.0"
     babel-template "^6.16.0"
 
-babel-messages@^6.23.0:
+babel-loader@^6.4.1:
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-6.4.1.tgz#0b34112d5b0748a8dcdbf51acf6f9bd42d50b8ca"
+  dependencies:
+    find-cache-dir "^0.1.1"
+    loader-utils "^0.2.16"
+    mkdirp "^0.5.1"
+    object-assign "^4.0.1"
+
+babel-messages@^6.23.0, babel-messages@^6.8.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
   dependencies:
     babel-runtime "^6.22.0"
-
-babel-messages@^6.8.0:
-  version "6.8.0"
-  resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.8.0.tgz#bf504736ca967e6d65ef0adb5a2a5f947c8e0eb9"
-  dependencies:
-    babel-runtime "^6.0.0"
 
 babel-plugin-check-es2015-constants@^6.22.0:
   version "6.22.0"
@@ -687,31 +682,14 @@ babel-runtime@5.5.*:
   dependencies:
     core-js "^0.9.0"
 
-babel-runtime@^6.0.0, babel-runtime@^6.11.6, babel-runtime@^6.9.0, babel-runtime@^6.9.1:
-  version "6.11.6"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.11.6.tgz#6db707fef2d49c49bfa3cb64efdb436b518b8222"
-  dependencies:
-    core-js "^2.4.0"
-    regenerator-runtime "^0.9.5"
-
-babel-runtime@^6.18.0, babel-runtime@^6.22.0:
+babel-runtime@^6.0.0, babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.9.0, babel-runtime@^6.9.1:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-template@^6.16.0:
-  version "6.16.0"
-  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.16.0.tgz#e149dd1a9f03a35f817ddbc4d0481988e7ebc8ca"
-  dependencies:
-    babel-runtime "^6.9.0"
-    babel-traverse "^6.16.0"
-    babel-types "^6.16.0"
-    babylon "^6.11.0"
-    lodash "^4.2.0"
-
-babel-template@^6.22.0, babel-template@^6.23.0:
+babel-template@^6.16.0, babel-template@^6.22.0, babel-template@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.23.0.tgz#04d4f270adbb3aa704a8143ae26faa529238e638"
   dependencies:
@@ -721,21 +699,7 @@ babel-template@^6.22.0, babel-template@^6.23.0:
     babylon "^6.11.0"
     lodash "^4.2.0"
 
-babel-traverse@^6.16.0:
-  version "6.16.0"
-  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.16.0.tgz#fba85ae1fd4d107de9ce003149cc57f53bef0c4f"
-  dependencies:
-    babel-code-frame "^6.16.0"
-    babel-messages "^6.8.0"
-    babel-runtime "^6.9.0"
-    babel-types "^6.16.0"
-    babylon "^6.11.0"
-    debug "^2.2.0"
-    globals "^8.3.0"
-    invariant "^2.2.0"
-    lodash "^4.2.0"
-
-babel-traverse@^6.22.0, babel-traverse@^6.23.0:
+babel-traverse@^6.16.0, babel-traverse@^6.22.0, babel-traverse@^6.23.0:
   version "6.23.1"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.23.1.tgz#d3cb59010ecd06a97d81310065f966b699e14f48"
   dependencies:
@@ -749,16 +713,7 @@ babel-traverse@^6.22.0, babel-traverse@^6.23.0:
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-types@^6.16.0:
-  version "6.16.0"
-  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.16.0.tgz#71cca1dbe5337766225c5c193071e8ebcbcffcfe"
-  dependencies:
-    babel-runtime "^6.9.1"
-    esutils "^2.0.2"
-    lodash "^4.2.0"
-    to-fast-properties "^1.0.1"
-
-babel-types@^6.19.0, babel-types@^6.22.0, babel-types@^6.23.0:
+babel-types@^6.16.0, babel-types@^6.19.0, babel-types@^6.22.0, babel-types@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.23.0.tgz#bb17179d7538bad38cd0c9e115d340f77e7e9acf"
   dependencies:
@@ -2574,6 +2529,14 @@ finalhandler@0.5.0:
     statuses "~1.3.0"
     unpipe "~1.0.0"
 
+find-cache-dir@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-0.1.1.tgz#c8defae57c8a52a8a784f9e31c57c742e993a0b9"
+  dependencies:
+    commondir "^1.0.1"
+    mkdirp "^0.5.1"
+    pkg-dir "^1.0.0"
+
 find-index@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/find-index/-/find-index-0.1.1.tgz#675d358b2ca3892d795a1ab47232f8b6e2e0dde4"
@@ -3005,10 +2968,6 @@ global-prefix@^0.1.4:
     osenv "^0.1.3"
     which "^1.2.10"
 
-globals@^8.3.0:
-  version "8.18.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-8.18.0.tgz#93d4a62bdcac38cfafafc47d6b034768cb0ffcb4"
-
 globals@^9.0.0, globals@^9.2.0:
   version "9.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.12.0.tgz#992ce90828c3a55fa8f16fada177adb64664cf9d"
@@ -3307,7 +3266,7 @@ gulp-rename@^1.2.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/gulp-rename/-/gulp-rename-1.2.2.tgz#3ad4428763f05e2764dec1c67d868db275687817"
 
-gulp-sass-glob@tomgrooffer/gulp-sass-glob#99d06af:
+"gulp-sass-glob@github:tomgrooffer/gulp-sass-glob#99d06af":
   version "1.0.8"
   resolved "https://codeload.github.com/tomgrooffer/gulp-sass-glob/tar.gz/99d06af"
   dependencies:
@@ -3452,6 +3411,15 @@ gulp-util@~2.2.14:
     multipipe "^0.1.0"
     through2 "^0.5.0"
     vinyl "^0.2.1"
+
+"gulp@github:gulpjs/gulp#4.0":
+  version "4.0.0-alpha.2"
+  resolved "https://codeload.github.com/gulpjs/gulp/tar.gz/3f5aba28718dc19e4bf600fb88f128158ff2ff83"
+  dependencies:
+    glob-watcher "^3.0.0"
+    gulp-cli "^1.0.0"
+    undertaker "^1.0.0"
+    vinyl-fs "^2.0.0"
 
 gulp@gulpjs/gulp#4.0:
   version "4.0.0-alpha.2"
@@ -4099,10 +4067,6 @@ js-base64@^2.1.9:
 js-tokens@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-1.0.3.tgz#14e56eb68c8f1a92c43d59f5014ec29dc20f2ae1"
-
-js-tokens@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-2.0.0.tgz#79903f5563ee778cc1162e6dcf1a0027c97f9cb5"
 
 js-tokens@^3.0.0:
   version "3.0.1"
@@ -5533,9 +5497,9 @@ osx-release@^1.0.0:
   dependencies:
     minimist "^1.1.0"
 
-p2-theme-core@^9.3.1:
-  version "9.4.0"
-  resolved "https://registry.yarnpkg.com/p2-theme-core/-/p2-theme-core-9.4.0.tgz#6147a1b83384afffcedd8352fa740b7dae362a0e"
+p2-theme-core@^9.4.3:
+  version "9.4.3"
+  resolved "https://registry.yarnpkg.com/p2-theme-core/-/p2-theme-core-9.4.3.tgz#5ba4e2a3b799ae27126a926ed7bf54873e2430dd"
   dependencies:
     autoprefixer "^6.3.6"
     browser-sync "^2.12.8"
@@ -5801,11 +5765,7 @@ postcss-less@^0.14.0:
   dependencies:
     postcss "^5.0.21"
 
-postcss-media-query-parser@^0.2.0:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/postcss-media-query-parser/-/postcss-media-query-parser-0.2.1.tgz#b7389644997a5718d05d008756ecafc5f9cf22c9"
-
-postcss-media-query-parser@^0.2.3:
+postcss-media-query-parser@^0.2.0, postcss-media-query-parser@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz#27b39c6f4d94f81b1a73b8f76351c609e5cef244"
 
@@ -6096,10 +6056,6 @@ regenerate@^1.2.1:
 regenerator-runtime@^0.10.0:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.3.tgz#8c4367a904b51ea62a908ac310bf99ff90a82a3e"
-
-regenerator-runtime@^0.9.5:
-  version "0.9.5"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz#403d6d40a4bdff9c330dd9392dcbb2d9a8bba1fc"
 
 regenerator-transform@0.9.8:
   version "0.9.8"


### PR DESCRIPTION
Let's get Webpack in! I've pushed out `p2-theme-core` v9.4 which adds support for it. This branch has disabled the previous JS tasks that aggregate and babelify all JS files in the theme into one big JS file and have currently set up the very basics of some JS files in `./js`. There are several things left to do and @illepic has volunteered to help me get them going. Here's what I see as necessary to cover:

- [ ] Giving Pattern Lab some extra dependencies that Drupal would not get like jQuery, jQuery Once, and domready to name a few.
- [ ] How to make sure that Drupal JS Behaviors integrates in properly.
- [ ] Updating `npm run new` so that when new JS files are created they are set up like we'd like.