### PR TITLE
Add a setup command to facilitate integration with other tooling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
 install:
   - npm install
-  - npm setup
+  - npm run setup
 before_script:
   - php --version
   - node --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_install:
   - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
 install:
   - npm install
+  - npm setup
 before_script:
   - php --version
   - node --version

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ```bash
 npm install # or `yarn install` if you want 3x the speed
-npm setup
+npm run setup
 npm start
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 
 ```bash
 npm install # or `yarn install` if you want 3x the speed
+npm setup
 npm start
 ```
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "update": "npm update && cd pattern-lab && composer update",
     "new": "yo ./scripts/new-component/index.js",
     "setup": "bower install --allow-root && cd pattern-lab && composer install --no-interaction && npm run compile",
-    "postinstall": "find node_modules/ -name \"*.info\" -type f -delete && bower install --allow-root && cd pattern-lab && composer install --no-interaction",
+    "postinstall": "find node_modules/ -name \"*.info\" -type f -delete",
     "bower": "bower"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "gulp": "gulp",
     "update": "npm update && cd pattern-lab && composer update",
     "new": "yo ./scripts/new-component/index.js",
-    "setup": "bower install --allow-root && cd pattern-lab && composer install --no-interaction && npm run compile",
+    "setup": "bower install --allow-root && cd pattern-lab && composer install --no-interaction",
     "postinstall": "find node_modules/ -name \"*.info\" -type f -delete",
     "bower": "bower"
   },

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "gulp": "gulp",
     "update": "npm update && cd pattern-lab && composer update",
     "new": "yo ./scripts/new-component/index.js",
+    "setup": "bower install --allow-root && cd pattern-lab && composer install --no-interaction && npm run compile",
     "postinstall": "find node_modules/ -name \"*.info\" -type f -delete && bower install --allow-root && cd pattern-lab && composer install --no-interaction",
     "bower": "bower"
   },


### PR DESCRIPTION
As pattern lab starter is often used as part of a Drupal theme and a
larger project, a setup command provides the ability for tools like
grunt drupal tasks to request a theme compile which won't fail due to
a missing prior request to install dependencies.