### PR TITLE
Issue #137: Add Faker Twig Function

### DIFF
--- a/source/_twig-components/functions/faker.function.php
+++ b/source/_twig-components/functions/faker.function.php
@@ -1,0 +1,10 @@
+<?php
+
+$function = new Twig_SimpleFunction('faker', function ($string, $options="") {
+  $faker = Faker\Factory::create();
+  if ($options != "") {
+    return $faker->$string($options);
+  } else {
+    return $faker->$string;
+  }
+});


### PR DESCRIPTION
Twig function for simple Faker use in templates, from comments on [php twig edition](https://github.com/pattern-lab/edition-php-twig-standard/issues/7). Allows for:

```
{{ faker('property', 'options' }}
```

This comes with some caveats of use, but think this would still be a good addition. See issue #137 for original write-up. 