### PR TITLE
Remove table code blocks and add inline usage description

### DIFF
--- a/source/_patterns/00-base/demo/tables.twig
+++ b/source/_patterns/00-base/demo/tables.twig
@@ -11,10 +11,10 @@
     <p class="lead">Documentation and examples for opt-in styling of tables (given their prevelant use in JavaScript plugins) with Bootstrap.</p>
     <h2>Examples</h2>
     <h3 class="py-2">Basic</h3>
-
+    <p>Quickly create a table style with the <code>.table</code> class as <code>&lt;table class="table"&gt;</code>.</p>
     <div class="p-4 border">
       <table class="table">
-        <caption>List of Users: This is a <code>&lt;caption&gt;&lt;/caption&gt;</code></caption>
+        <caption>This caption example was created with <code>&lt;caption&gt;&lt;/caption&gt;</code>.</caption>
         <thead>
           <tr>
             <th scope="col">#</th>
@@ -34,32 +34,10 @@
         {% endfor %}
         </tbody>
       </table>
-        <pre class="bg-light"><code>
-    &lt;table class="table"&gt;
-      &lt;caption&gt;List of Users&lt;/caption&gt;
-      &lt;thead&gt;
-        &lt;tr&gt;
-          &lt;th scope="col"&gt;#&lt;/th&gt;
-          {% for header in table_header %}
-            &lt;th scope="col"&gt;{{ header }}&lt;/th&gt;
-          {% endfor %}
-          &lt;/tr&gt;
-      &lt;/thead&gt;
-      &lt;tbody&gt;
-        {% for content in table_content %}
-        &lt;tr&gt;
-          &lt;th scope="row"&gt;{{ loop.index }}&lt;/th&gt;
-          &lt;td&gt;{{ content.first_name }}&lt;/td&gt;
-          &lt;td&gt;{{ content.last_name }}&lt;/td&gt;
-          &lt;td&gt;@{{ content.username }}&lt;/td&gt;
-        &lt;/tr&gt;
-        {% endfor %}
-      &lt;/tbody&gt;
-    &lt;/table&gt;</code></pre>
     </div>
 
     <h3 class="py-2">Dark Basic</h3>
-    <p>As easy as adding the <code>table-dark</code> class to the table!</p>
+    <p>As easy as adding the <code>table-dark</code> class to the table as <code>&lt;table class="table-dark"&gt;</code>!</p>
     <div class="p-4 border">
       <table class="table table-dark">
         <thead>
@@ -81,31 +59,13 @@
         {% endfor %}
         </tbody>
       </table>
-      <pre class="bg-light"><code>
-    &lt;table class="table table-dark"&gt;
-      &lt;thead&gt;
-        &lt;tr&gt;
-          &lt;th scope="col"&gt;#&lt;/th&gt;
-          {% for header in table_header %}
-          &lt;th scope="col"&gt;{{ header }}&lt;/th&gt;
-          {% endfor %}
-        &lt;/tr&gt;
-      &lt;/thead&gt;
-      &lt;tbody&gt;
-        {% for content in table_content %}
-        &lt;tr&gt;
-          &lt;th scope="row"&gt;{{ loop.index }}&lt;/th&gt;
-          &lt;td&gt;{{ content.first_name }}&lt;/td&gt;
-          &lt;td&gt;{{ content.last_name }}&lt;/td&gt;
-          &lt;td&gt;@{{ content.username }}&lt;/td&gt;
-        &lt;/tr&gt;
-        {% endfor %}
-      &lt;/tbody&gt;
-    &lt;/table&gt;</code></pre>
     </div>
 
     <h3 class="py-2">Table Head Options</h3>
-    <p>Similar to tables and dark tables, use the modifier classes <code>.thead-light</code> or <code>.thead-dark</code> to make <code>&lt;thead&gt;</code>s appear light or dark gray.</p>
+    <p>
+      Similar to tables and dark tables, use the modifier classes <code>.thead-light</code> or <code>.thead-dark</code> in your <code>&lt;thead&gt;</code> for a light or dark gray appearance.
+      For example, <code>&lt;thead class="thead-dark"&gt;</code> or <code>&lt;thead class="thead-light"&gt;</code>.
+    </p>
     <div class="p-4 border">
       <table class="table">
         <thead class="thead-dark">
@@ -127,27 +87,6 @@
         {% endfor %}
         </tbody>
       </table>
-      <pre class="bg-light"><code>
-    &lt;table class="table"&gt;
-      &lt;thead class="thead-dark"&gt;
-        &lt;tr&gt;
-          &lt;th scope="col"&gt;#&lt;/th&gt;
-          {% for header in table_header %}
-          &lt;th scope="col"&gt;{{ header }}&lt;/th&gt;
-          {% endfor %}
-        &lt;/tr&gt;
-      &lt;/thead&gt;
-      &lt;tbody&gt;
-        {% for content in table_content %}
-        &lt;tr&gt;
-          &lt;th scope="row"&gt;{{ loop.index }}&lt;/th&gt;
-          &lt;td&gt;{{ content.first_name }}&lt;/td&gt;
-          &lt;td&gt;{{ content.last_name }}&lt;/td&gt;
-          &lt;td&gt;@{{ content.username }}&lt;/td&gt;
-        &lt;/tr&gt;
-        {% endfor %}
-      &lt;/tbody&gt;
-    &lt;/table&gt;</code></pre>
     </div>
 
     <div class="p-4 border">
@@ -171,31 +110,13 @@
         {% endfor %}
         </tbody>
       </table>
-      <pre class="bg-light"><code>
-    &lt;table class="table"&gt;
-      &lt;thead class="thead-light"&gt;
-        &lt;tr&gt;
-          &lt;th scope="col"&gt;#&lt;/th&gt;
-          {% for header in table_header %}
-          &lt;th scope="col"&gt;{{ header }}&lt;/th&gt;
-          {% endfor %}
-        &lt;/tr&gt;
-      &lt;/thead&gt;
-      &lt;tbody&gt;
-        {% for content in table_content %}
-        &lt;tr&gt;
-          &lt;th scope="row"&gt;{{ loop.index }}&lt;/th&gt;
-          &lt;td&gt;{{ content.first_name }}&lt;/td&gt;
-          &lt;td&gt;{{ content.last_name }}&lt;/td&gt;
-          &lt;td&gt;@{{ content.username }}&lt;/td&gt;
-        &lt;/tr&gt;
-        {% endfor %}
-      &lt;/tbody&gt;
-    &lt;/table&gt;</code></pre>
     </div>
 
     <h3 class="py-2">Striped Rows</h3>
-    <p>Use <code>.table-striped</code> to add zebra-striping to any table row within the <code>&lt;tbody&gt;</code>.</p>
+    <p>
+      Use the <code>.table-striped</code> class with basic or dark tables to add zebra-striping to any table.
+      <code>&lt;table class="table table-striped"&gt;</code> or <code>&lt;table class="table table-dark table-striped"&gt;</code>
+    </p>
     <div class="p-4 border">
       <table class="table table-striped">
         <thead>
@@ -217,27 +138,6 @@
         {% endfor %}
         </tbody>
       </table>
-      <pre class="bg-light"><code>
-    &lt;table class="table table-striped"&gt;
-      &lt;thead&gt;
-        &lt;tr&gt;
-          &lt;th scope="col"&gt;#&lt;/th&gt;
-          {% for header in table_header %}
-          &lt;th scope="col"&gt;{{ header }}&lt;/th&gt;
-          {% endfor %}
-        &lt;/tr&gt;
-      &lt;/thead&gt;
-      &lt;tbody&gt;
-        {% for content in table_content %}
-        &lt;tr&gt;
-          &lt;th scope="row"&gt;{{ loop.index }}&lt;/th&gt;
-          &lt;td&gt;{{ content.first_name }}&lt;/td&gt;
-          &lt;td&gt;{{ content.last_name }}&lt;/td&gt;
-          &lt;td&gt;@{{ content.username }}&lt;/td&gt;
-        &lt;/tr&gt;
-        {% endfor %}
-      &lt;/tbody&gt;
-    &lt;/table&gt;</code></pre>
 
       <table class="table table-dark table-striped">
         <thead>
@@ -259,31 +159,13 @@
         {% endfor %}
         </tbody>
       </table>
-      <pre class="bg-light"><code>
-    &lt;table class="table table-dark table-striped"&gt;
-      &lt;thead&gt;
-        &lt;tr&gt;
-          &lt;th scope="col"&gt;#&lt;/th&gt;
-          {% for header in table_header %}
-          &lt;th scope="col"&gt;{{ header }}&lt;/th&gt;
-          {% endfor %}
-        &lt;/tr&gt;
-      &lt;/thead&gt;
-      &lt;tbody&gt;
-        {% for content in table_content %}
-        &lt;tr&gt;
-          &lt;th scope="row"&gt;{{ loop.index }}&lt;/th&gt;
-          &lt;td&gt;{{ content.first_name }}&lt;/td&gt;
-          &lt;td&gt;{{ content.last_name }}&lt;/td&gt;
-          &lt;td&gt;@{{ content.username }}&lt;/td&gt;
-        &lt;/tr&gt;
-        {% endfor %}
-      &lt;/tbody&gt;
-    &lt;/table&gt;</code></pre>
     </div>
 
     <h3 class="py-2">Bordered table</h3>
-    <p>Add <code>.table-bordered</code> for borders on all sides of the table and cells.</p>
+    <p>
+      Add <code>.table-bordered</code> for borders on all sides of the table and cells. Available for both basic and dark tables.
+      <code>&lt;table class="table table-bordered"&gt;</code> or <code>&lt;table class="table table-dark table-bordered"&gt;</code>
+    </p>
     <div class="p-4 border">
       <table class="table table-bordered">
         <thead>
@@ -305,27 +187,6 @@
         {% endfor %}
         </tbody>
       </table>
-      <pre class="bg-light"><code>
-    &lt;table class="table table-bordered"&gt;
-      &lt;thead&gt;
-        &lt;tr&gt;
-          &lt;th scope="col"&gt;#&lt;/th&gt;
-          {% for header in table_header %}
-          &lt;th scope="col"&gt;{{ header }}&lt;/th&gt;
-          {% endfor %}
-        &lt;/tr&gt;
-      &lt;/thead&gt;
-      &lt;tbody&gt;
-        {% for content in table_content %}
-        &lt;tr&gt;
-          &lt;th scope="row"&gt;{{ loop.index }}&lt;/th&gt;
-          &lt;td&gt;{{ content.first_name }}&lt;/td&gt;
-          &lt;td&gt;{{ content.last_name }}&lt;/td&gt;
-          &lt;td&gt;@{{ content.username }}&lt;/td&gt;
-        &lt;/tr&gt;
-        {% endfor %}
-      &lt;/tbody&gt;
-    &lt;/table&gt;</code></pre>
 
       <table class="table table-dark table-bordered">
         <thead>
@@ -347,31 +208,13 @@
         {% endfor %}
         </tbody>
       </table>
-      <pre class="bg-light"><code>
-    &lt;table class="table table-dark table-bordered"&gt;
-      &lt;thead&gt;
-        &lt;tr&gt;
-          &lt;th scope="col"&gt;#&lt;/th&gt;
-          {% for header in table_header %}
-          &lt;th scope="col"&gt;{{ header }}&lt;/th&gt;
-          {% endfor %}
-        &lt;/tr&gt;
-      &lt;/thead&gt;
-      &lt;tbody&gt;
-        {% for content in table_content %}
-        &lt;tr&gt;
-          &lt;th scope="row"&gt;{{ loop.index }}&lt;/th&gt;
-          &lt;td&gt;{{ content.first_name }}&lt;/td&gt;
-          &lt;td&gt;{{ content.last_name }}&lt;/td&gt;
-          &lt;td&gt;@{{ content.username }}&lt;/td&gt;
-        &lt;/tr&gt;
-        {% endfor %}
-      &lt;/tbody&gt;
-    &lt;/table&gt;</code></pre>
     </div>
 
     <h3 class="py-2">Hoverable rows</h3>
-    <p>Add <code>.table-hover</code> to enable a hover state on table rows within a <code>&lt;tbody&gt;</code>.</p>
+    <p>
+      Add <code>.table-hover</code> to enable a hover state on table rows within a <code>&lt;tbody&gt;</code>.
+      <code>&lt;table class="table table-hover"&gt;</code> or <code>&lt;table class="table table-dark table-hover"&gt;</code>
+    </p>
     <div class="p-4 border">
       <table class="table table-hover">
         <thead>
@@ -393,27 +236,6 @@
           {% endfor %}
         </tbody>
       </table>
-      <pre class="bg-light"><code>
-    &lt;table class="table table-hover"&gt;
-      &lt;thead&gt;
-        &lt;tr&gt;
-          &lt;th scope="col"&gt;#&lt;/th&gt;
-          {% for header in table_header %}
-          &lt;th scope="col"&gt;{{ header }}&lt;/th&gt;
-          {% endfor %}
-        &lt;/tr&gt;
-      &lt;/thead&gt;
-      &lt;tbody&gt;
-        {% for content in table_content %}
-        &lt;tr&gt;
-          &lt;th scope="row"&gt;{{ loop.index }}&lt;/th&gt;
-          &lt;td&gt;{{ content.first_name }}&lt;/td&gt;
-          &lt;td&gt;{{ content.last_name }}&lt;/td&gt;
-          &lt;td&gt;@{{ content.username }}&lt;/td&gt;
-        &lt;/tr&gt;
-        {% endfor %}
-      &lt;/tbody&gt;
-    &lt;/table&gt;</code></pre>
 
       <table class="table table-dark table-hover">
         <thead>
@@ -435,31 +257,13 @@
         {% endfor %}
         </tbody>
       </table>
-      <pre class="bg-light"><code>
-    &lt;table class="table table-dark table-hover"&gt;
-      &lt;thead&gt;
-        &lt;tr&gt;
-          &lt;th scope="col"&gt;#&lt;/th&gt;
-          {% for header in table_header %}
-          &lt;th scope="col"&gt;{{ header }}&lt;/th&gt;
-          {% endfor %}
-        &lt;/tr&gt;
-      &lt;/thead&gt;
-      &lt;tbody&gt;
-        {% for content in table_content %}
-        &lt;tr&gt;
-          &lt;th scope="row"&gt;{{ loop.index }}&lt;/th&gt;
-          &lt;td&gt;{{ content.first_name }}&lt;/td&gt;
-          &lt;td&gt;{{ content.last_name }}&lt;/td&gt;
-          &lt;td&gt;@{{ content.username }}&lt;/td&gt;
-        &lt;/tr&gt;
-        {% endfor %}
-      &lt;/tbody&gt;
-    &lt;/table&gt;</code></pre>
     </div>
 
     <h3 class="py-2">Small table</h3>
-    <p>Add <code>.table-sm</code> to make tables more compact by cutting cell padding in half.</p>
+    <p>
+      Add <code>.table-sm</code> to make tables more compact by cutting cell padding in half.
+      <code>&lt;table class="table table-sm"&gt;</code> or <code>&lt;table class="table table-dark table-sm"&gt;</code>
+    </p>
     <div class="p-4 border">
       <table class="table table-sm">
         <thead>
@@ -481,27 +285,6 @@
         {% endfor %}
         </tbody>
       </table>
-      <pre class="bg-light"><code>
-    &lt;table class="table table-sm"&gt;
-      &lt;thead&gt;
-        &lt;tr&gt;
-          &lt;th scope="col"&gt;#&lt;/th&gt;
-          {% for header in table_header %}
-          &lt;th scope="col"&gt;{{ header }}&lt;/th&gt;
-          {% endfor %}
-        &lt;/tr&gt;
-      &lt;/thead&gt;
-      &lt;tbody&gt;
-        {% for content in table_content %}
-        &lt;tr&gt;
-          &lt;th scope="row"&gt;{{ loop.index }}&lt;/th&gt;
-          &lt;td&gt;{{ content.first_name }}&lt;/td&gt;
-          &lt;td&gt;{{ content.last_name }}&lt;/td&gt;
-          &lt;td&gt;@{{ content.username }}&lt;/td&gt;
-        &lt;/tr&gt;
-        {% endfor %}
-      &lt;/tbody&gt;
-    &lt;/table&gt;</code></pre>
 
       <table class="table table-dark table-sm">
         <thead>
@@ -523,27 +306,6 @@
         {% endfor %}
         </tbody>
       </table>
-      <pre class="bg-light"><code>
-    &lt;table class="table table-dark table-sm"&gt;
-      &lt;thead&gt;
-        &lt;tr&gt;
-          &lt;th scope="col"&gt;#&lt;/th&gt;
-          {% for header in table_header %}
-          &lt;th scope="col"&gt;{{ header }}&lt;/th&gt;
-          {% endfor %}
-        &lt;/tr&gt;
-      &lt;/thead&gt;
-      &lt;tbody&gt;
-        {% for content in table_content %}
-        &lt;tr&gt;
-          &lt;th scope="row"&gt;{{ loop.index }}&lt;/th&gt;
-          &lt;td&gt;{{ content.first_name }}&lt;/td&gt;
-          &lt;td&gt;{{ content.last_name }}&lt;/td&gt;
-          &lt;td&gt;@{{ content.username }}&lt;/td&gt;
-        &lt;/tr&gt;
-        {% endfor %}
-      &lt;/tbody&gt;
-    &lt;/table&gt;</code></pre>
     </div>
 
     <h3 class="py-2">Contextual classes</h3>


### PR DESCRIPTION
This PR removes the code blocks for Bootstrap tables in Pattern Lab in favor of describing the code inline in the opening paragraph text. 